### PR TITLE
The methods that can return an IdentityResult now does so instead of throwing validationexceptions.

### DIFF
--- a/NetForum/ErrorMessageBuilder/ErrorMessageBuilder.cs
+++ b/NetForum/ErrorMessageBuilder/ErrorMessageBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using System.Data.Entity.Validation;
 
@@ -32,8 +31,11 @@ namespace MessageBuilder
 
             foreach (var error in errors)
             {
-                stringBuilder.AppendLine();
-                stringBuilder.Append(error);
+                foreach (var validationError in error.ValidationErrors)
+                {
+                    stringBuilder.AppendLine();
+                    stringBuilder.Append(validationError.ErrorMessage);
+                }
             }
 
             return stringBuilder.ToString();

--- a/NetForum/IntegrationTests/Repository/UserRepository.cs
+++ b/NetForum/IntegrationTests/Repository/UserRepository.cs
@@ -8,7 +8,6 @@ using System.Transactions;
 using Microsoft.AspNet.Identity;
 using System.Data.Entity.Validation;
 using System.Linq;
-using DataSupplier;
 
 namespace IntegrationTests.Repository
 {
@@ -93,11 +92,23 @@ namespace IntegrationTests.Repository
         [TestMethod]
         [TestCategory("Integration")]
         [ExpectedException(typeof(DbEntityValidationException))]
-        public async Task RegisterFail()
+        public async Task RegisterFailOnSameUser()
         {
             using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {
                 await _sut.Register(_user, _password);
+                await _sut.Register(_user, _password);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        [ExpectedException(typeof(DbEntityValidationException))]
+        public async Task RegisterFailOnUserNameLongerThanThirtyCharacters()
+        {
+            using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                _user.UserName = string.Concat(Enumerable.Repeat("A", 35));
                 await _sut.Register(_user, _password);
             }
         }

--- a/NetForum/UnitTests/Application Services/UserAccountService/RegisterServiceTest.cs
+++ b/NetForum/UnitTests/Application Services/UserAccountService/RegisterServiceTest.cs
@@ -53,70 +53,21 @@ namespace UnitTests.Application_Services.UserAccountService
         #region Tests
         [TestMethod]
         [TestCategory("UnitTest")]
-        [ExpectedException(typeof(ServerValidationException))]
-        public async Task RegisterAsyncSuccessServerValidationSuccess()
-        {
-            await _sut.Register(_user, _password);
-        }
-
-        [TestMethod]
-        [TestCategory("UnitTest")]
-        [ExpectedException(typeof(ServerValidationException))]
-        public async Task RegisterAsyncSuccessServerValidationError()
-        {
-            await _sut.Register(_user, _password);
-        }
-
-        [TestMethod]
-        [TestCategory("UnitTest")]
         public async Task RegisterAsyncValidationTypeSuccess()
         {
-            var exception = new ServerValidationException();
+            var identityResult = await _sut.Register(_user, _password);
 
-            try
-            {
-                await _sut.Register(_user, _password);
-            }
-            catch (ServerValidationException ex)
-            {
-                exception = ex;
-            }
-
-            Assert.AreEqual(ServerValidationException.ServerValidationExceptionType.Success, exception.ValidationExceptionType);
+            Assert.IsTrue(identityResult.Succeeded);
         }
 
         [TestMethod]
         [TestCategory("UnitTest")]
         public async Task RegisterAsyncValidationTypeError()
         {
-            var exception = new ServerValidationException();
+            _userRepository.Setup(x => x.Register(_user, _password)).Returns(Task.FromResult(new IdentityResult()));
+            var identityResult = await _sut.Register(_user, _password);
 
-            try
-            {
-                _userRepository.Setup(x => x.Register(_user, _password)).Returns(Task.FromResult(new IdentityResult()));
-                await _sut.Register(_user, _password);
-            }
-            catch (ServerValidationException ex)
-            {
-                exception = ex;
-            }
-            Assert.AreEqual(ServerValidationException.ServerValidationExceptionType.Error, exception.ValidationExceptionType);
-        }
-
-        [TestMethod]
-        [TestCategory("UnitTest")]
-        public async Task RegisterAsyncCorrectAmountOfRowsInSuccessMessage()
-        {
-            const int amountOfRows = 1;
-            try
-            {
-                await _sut.Register(_user, _password);
-            }
-            catch (ServerValidationException ex)
-            {
-                int numLines = ex.Message.Split('\n').Length;
-                Assert.AreEqual(amountOfRows, numLines);
-            }
+            Assert.IsFalse(identityResult.Succeeded);
         }
 
         [TestMethod]

--- a/NetForum/UserAccountService/Interface/IRegisterService.cs
+++ b/NetForum/UserAccountService/Interface/IRegisterService.cs
@@ -7,6 +7,6 @@ namespace UserAccountServiceNameSpace.Interface
 {
     public interface IRegisterService : IDisposable
     {
-        Task Register(User _user, string _password);
+        Task<IdentityResult> Register(User _user, string _password);
     }
 }

--- a/NetForum/UserAccountService/Interface/IUserService.cs
+++ b/NetForum/UserAccountService/Interface/IUserService.cs
@@ -10,6 +10,6 @@ namespace UserAccountServiceNameSpace.Interface
     {
         Task<IEnumerable<User>> GetAllAsync();
         Task<User> GetAsync(User user);
-        Task UpdateAsync(User _user);
+        Task<IdentityResult> UpdateAsync(User _user);
     }
 }

--- a/NetForum/UserAccountService/Service/RegisterService.cs
+++ b/NetForum/UserAccountService/Service/RegisterService.cs
@@ -28,16 +28,11 @@ namespace UserAccountServiceNameSpace.Service
             _uow.Dispose();
         }
 
-        public async Task Register(User user, string password)
+        public async Task<IdentityResult> Register(User user, string password)
         {
             try
             {
-                var identityResult = await _userRepository.Register(user, password);
-                if (identityResult.Succeeded)
-                    throw new ServerValidationException("Register successful!", ServerValidationException.ServerValidationExceptionType.Success);
-
-                if (!identityResult.Succeeded || (identityResult.Errors.Any() && !identityResult.Succeeded))
-                    throw new ServerValidationException(ErrorMessageBuilder.BuildErrorMessage("Registration failed due to these issues: ", identityResult.Errors), ServerValidationException.ServerValidationExceptionType.Error);
+                return await _userRepository.Register(user, password);
             }
             catch (DbEntityValidationException ex)
             {

--- a/NetForum/UserAccountService/Service/UserService.cs
+++ b/NetForum/UserAccountService/Service/UserService.cs
@@ -1,7 +1,7 @@
 ﻿using Domain.Interface;
 using Domain.Model;
 using Exceptions.Validation;
-using MessageBuilder;
+using Microsoft.AspNet.Identity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -61,16 +61,11 @@ namespace UserAccountServiceNameSpace.Service
             }
         }
 
-        public async Task UpdateAsync(User user)
+        public async Task<IdentityResult> UpdateAsync(User user)
         {
             try
             {
-                var identityResult = await _userRepository.UpdateAsync(user);
-                if (identityResult.Succeeded)
-                    throw new ServerValidationException("Update successful!", ServerValidationException.ServerValidationExceptionType.Success);
-
-                if (!identityResult.Succeeded || (identityResult.Errors.Any() && !identityResult.Succeeded))
-                    throw new ServerValidationException(ErrorMessageBuilder.BuildErrorMessage("Update failed due to these issues: ", identityResult.Errors), ServerValidationException.ServerValidationExceptionType.Error);
+                return await _userRepository.UpdateAsync(user);
             }
             catch (Exception)
             {


### PR DESCRIPTION
I realised that throwing exceptions all the time, even for positive validation could cause performance issues in the future. Therefore some methods that are using the Identity framework can instead return IdentityResult objects. Other methods that are not using the Identity framework are still throwing validation exceptions when needed. Unit tests and Integration tests are updated.